### PR TITLE
removed Amazon Web Services Plugin

### DIFF
--- a/build-wp.sh
+++ b/build-wp.sh
@@ -9,11 +9,6 @@ then
     mv wordpress/* wp/
     rm -rf wordpress
 
-    curl -O https://downloads.wordpress.org/plugin/amazon-web-services.latest-stable.zip
-    unzip amazon-web-services.latest-stable.zip
-    rm amazon-web-services.latest-stable.zip
-    mv amazon-web-services wp/wp-content/plugins/
-
     curl -O https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.latest-stable.zip
     unzip amazon-s3-and-cloudfront.latest-stable.zip
     rm amazon-s3-and-cloudfront.latest-stable.zip


### PR DESCRIPTION
According to Delicious Brains, this plugin was initially developed for their use on (WP Offload S3 and WP Offload S3 Lite) but now they "realized however that there are problems with this idea and we’ve taken another approach." as this is no longer needed to work with S3 and Digitalocean spaces offload plugin.