### PR TITLE
mv instead of cp

### DIFF
--- a/util/directory.js
+++ b/util/directory.js
@@ -5,7 +5,7 @@ exports.setup = function() {
     if (!fs.existsSync('/tmp/wp')) {
         fs.mkdirSync('/tmp/wp');
         try {
-            execSync('cp -R /var/task/wp/* /tmp/wp/');
+            execSync('mv /var/task/wp /tmp/');
         }
         catch (err) {
             console.log(err);


### PR DESCRIPTION
Move a dir is faster and space saver on the container