### PR TITLE
Set default Node.js version to 18.x to fix one-click deployment on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "license": "MIT",
   "dependencies": {
     "serverlesswp": "^0.1.2"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
PR to fix issue #64 and #67 

Should prevent the following Serverless Function runtime error which is returned when using Node.js v20.x
```
/var/task/node_modules/serverlesswp/php-files/php: error while loading shared libraries: libssl.so.10: cannot open shared object file: No such file or directory
```

[Related comment](https://github.com/mitchmac/ServerlessWP/issues/67#issuecomment-2430713250)