### PR TITLE
Add WP_User_Query support for TiDB (SQL_CALC_FOUND_ROWS / FOUND_ROWS)

### DIFF
--- a/wp/wp-content/plugins/tidb-compatibility/tidb-compatibility.php
+++ b/wp/wp-content/plugins/tidb-compatibility/tidb-compatibility.php
@@ -31,9 +31,18 @@ class WTC_FIX_WP_SLOW_QUERY {
                         $wp_query->fw_clauses = $clauses;
                         return $clauses;
                 }, 999, 2 );
+
+                /**
+                 * WP_User_Query (admin users list, etc.)
+                 */
+                add_filter( 'found_users_query', [ __CLASS__, 'wtc_add_found_users_query' ], 999, 2 );
+                add_filter( 'users_pre_query', function ( $results, \WP_User_Query $query ) {
+                        $query->query_fields = self::wtc_remove_found_rows_query( $query->query_fields );
+                        return $results;
+                }, 999, 2 );
         }
         public static function wtc_remove_found_rows_query( $sql ) {
-                return str_replace( ' SQL_CALC_FOUND_ROWS ', '', $sql );
+                return preg_replace( '/\bSQL_CALC_FOUND_ROWS\s+/i', '', $sql );
         }
         public static function wtc_add_found_rows_query( $sql, WP_Query $query ) {
                 global $wpdb;
@@ -49,6 +58,16 @@ class WTC_FIX_WP_SLOW_QUERY {
                         SELECT $distinct $count
                         FROM {$wpdb->posts} $join
                         WHERE 1=1 $where
+                ";
+        }
+        public static function wtc_add_found_users_query( $sql, WP_User_Query $query ) {
+                global $wpdb;
+                $has_distinct = stripos( $query->query_fields, 'DISTINCT' ) !== false;
+                $count        = $has_distinct ? "COUNT( DISTINCT {$wpdb->users}.ID )" : 'COUNT(*)';
+                return "
+                        SELECT $count
+                        {$query->query_from}
+                        {$query->query_where}
                 ";
         }
 }


### PR DESCRIPTION
## Summary

Extends the existing `WP_Query` workaround to also cover `WP_User_Query`, which uses the same deprecated MySQL features. Without this, the WordPress admin **Users** screen shows correct tab counts (e.g. "All (3)") but the table displays **"No users found."**

## Problem

TiDB does not support `SQL_CALC_FOUND_ROWS` or `FOUND_ROWS()`. WordPress admin list tables rely on these for paginated queries:

| Screen | Count (works) | List table (broken without fix) |
|--------|---------------|----------------------------------|
| Posts  | `wp_count_posts()` | `WP_Query`      |
| Users  | `count_users()`    | `WP_User_Query` |

The plugin already patches `WP_Query` via `found_posts_query`, `posts_pre_query`, and related filters. **`WP_User_Query` was not covered**, so posts could display correctly while users could not.

## Solution

Mirror the `WP_Query` approach for `WP_User_Query`:

1. **`users_pre_query`** — Strip `SQL_CALC_FOUND_ROWS` from `$query->query_fields` before the SELECT is built and executed.
2. **`found_users_query`** — Replace `SELECT FOUND_ROWS()` with a `COUNT(*)` (or `COUNT(DISTINCT wp_users.ID)` when `DISTINCT` is present) using the query's existing `query_from` and `query_where` clauses.

Also harden **`wtc_remove_found_rows_query()`** to use `preg_replace` instead of `str_replace`, so removal works whether `SQL_CALC_FOUND_ROWS` appears after `SELECT` or at the start of `query_fields`.

## Changes

- Register `found_users_query` and `users_pre_query` filters in `wtc_init()`.
- Add `wtc_add_found_users_query()` for total user count on TiDB.
- Update `wtc_remove_found_rows_query()` to reliably remove `SQL_CALC_FOUND_ROWS` in all positions.

## Environment

Reproduced on WordPress 6.9.x with TiDB Cloud (MySQL-compatible protocol). Posts were fixed by activating this plugin; users remained broken until `WP_User_Query` was patched.